### PR TITLE
#46 popup on error, rather than redirect

### DIFF
--- a/src/bookmarklet/sgp.bookmarklet.js
+++ b/src/bookmarklet/sgp.bookmarklet.js
@@ -1,11 +1,10 @@
-(function ($) {
+(function () {
 
   // Configuration
   var version = 20140624;
   var domain = 'https://chriszarate.github.io';
   var mobile = 'https://chriszarate.github.io/supergenpass/mobile/';
   var minFrameArea = 100000;
-  var loadedSGP = false;
 
   // Main
   var loadSGP = function($) {
@@ -164,28 +163,27 @@
     http://pastie.org/462639
   */
 
-  var hasJQuery = $ && $.fn && parseFloat($.fn.jquery) >= 1.7 && loadSGP($);
+  var s = document.createElement('script');
+  s.src = '//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js';
+  s.onload = s.onreadystatechange = function() {
+    var state = this.readyState;
+    if(!state || state === 'loaded' || state === 'complete') {
+      loadSGP(jQuery.noConflict());
+    }
+  };
 
-  if(!hasJQuery) {
+  s.addEventListener('error', function(){ 
+    window.open(mobile,'','width=258, height=190');
+  });
 
-    var s = document.createElement('script');
-    s.src = '//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js';
-    s.onload = s.onreadystatechange = function() {
-      var state = this.readyState;
-      if(!state || state === 'loaded' || state === 'complete') {
-        loadSGP(jQuery.noConflict());
-      }
-    };
-
-    document.getElementsByTagName('head')[0].appendChild(s);
-
-  }
-
+  document.getElementsByTagName('head')[0].appendChild(s);
+  
   // Set timeout to see if SGP has loaded; otherwise assume that loading was
   // blocked by an origin policy or other content security setting.
   setTimeout(function() {
-    if(!loadedSGP) {
-      window.location = mobile;
+    if( !loadedSGP ) {
+      // will be blocked by pop-up blocker
+      window.open(mobile,'','width=258, height=190');
     }
   }, 2000);
 


### PR DESCRIPTION
My solution for #46, does a popup on error of the script load, and _always_ attempts a script injection as a method of trapping script injection blocking.  We do this on the assumption that if a site is blocking script injection, they're also blocking frame injection, and we can trap for script injection, but in order to trap for it, we can't skip loading the script in the case that the site is already hosting jQuery.
